### PR TITLE
fix: updated-return-assessment-question

### DIFF
--- a/src/modules/assessment/assessment.service.ts
+++ b/src/modules/assessment/assessment.service.ts
@@ -45,7 +45,6 @@ export class AssessmentService {
         delete assessment.questions;
         
         const assessmentsQuestion = {
-            assessment: [{
                 id: assessment.id,
                 createdAt: assessment.createdAt,
                 updatedAt: assessment.updatedAt,
@@ -53,7 +52,6 @@ export class AssessmentService {
                 title: assessment.title,
                 finishedAt: assessment.finishedAt,
                 questions
-            }]
         }
 
         return assessmentsQuestion;


### PR DESCRIPTION
Retirando apenas o array que continha apenas um valor gerado pelo (findOne), dessa forma, retirando o array (sendo necessário apenas quando fosse gerado mais de uma, que não é o caso).