### PR TITLE
fix: return all questions to score endpoint

### DIFF
--- a/src/modules/user-assessments/user-assessments.repository.ts
+++ b/src/modules/user-assessments/user-assessments.repository.ts
@@ -24,12 +24,12 @@ export class UserAssessmentsRepository extends Repository<UserAssessmentEntity> 
         return newUserAssessment
     }
 
-    public async createUserAssessment (assessment: AssessmentEntity, user: UsersEntity): Promise<UserAssessmentEntity> {
+    public async createUserAssessment (assessment: AssessmentEntity, user: UsersEntity, answers: object[]): Promise<UserAssessmentEntity> {
         const userAssessment = await this.save({            
             user,
             assessment,
             score: 0,
-            answers: [],
+            answers,
             status: 1,
         });
         return userAssessment


### PR DESCRIPTION
[PROBLEMA] As questões que não tinham sido respondidas pelo usuário não apareciam no resumo da prova.

[SOLUÇÃO] Agora ao iniciar a prova as questões serão registradas em userAssessment.answers inicialmente como null e conforme o usuário direcionar suas respostas elas serão alteradas de null para o id da alternativa.